### PR TITLE
Fix some bugs

### DIFF
--- a/android/src/main/java/com/ramitsuri/choresclient/android/data/TaskAssignment.kt
+++ b/android/src/main/java/com/ramitsuri/choresclient/android/data/TaskAssignment.kt
@@ -2,7 +2,6 @@ package com.ramitsuri.choresclient.android.data
 
 import androidx.room.ColumnInfo
 import androidx.room.Dao
-import androidx.room.Delete
 import androidx.room.Entity
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
@@ -55,6 +54,9 @@ abstract class TaskAssignmentDao {
     @Query("SELECT * FROM TaskAssignments")
     abstract suspend fun getAll(): List<TaskAssignmentEntity>
 
+    @Query("SELECT * FROM TaskAssignments WHERE progressStatus = 1")
+    abstract suspend fun getTodo(): List<TaskAssignmentEntity>
+
     @Query("SELECT * FROM TaskAssignments WHERE id = :id")
     abstract suspend fun get(id: String): TaskAssignmentEntity?
 
@@ -96,5 +98,15 @@ abstract class TaskAssignmentDao {
                 getForExceptMember(filterMode.ownUserId)
             }
         }
+    }
+
+    @Transaction
+    open suspend fun clearAndInsert(taskAssignmentEntities: List<TaskAssignmentEntity>) {
+        // Delete only incomplete assignments and not completed ones that haven't been uploaded.
+        // Even though it's unlikely to happen that a completed assignment is not uploaded at this
+        // point in the real flow
+        val todo = getTodo()
+        delete(todo.map { it.id })
+        insert(taskAssignmentEntities)
     }
 }

--- a/android/src/main/java/com/ramitsuri/choresclient/android/data/TaskAssignmentDataSource.kt
+++ b/android/src/main/java/com/ramitsuri/choresclient/android/data/TaskAssignmentDataSource.kt
@@ -22,7 +22,7 @@ class TaskAssignmentDataSource @Inject constructor(
         val taskAssignments = assignments.map { TaskAssignmentEntity(it) }
         // Do not do clearAndInsert as there might be local assignments that have been completed
         // but not uploaded
-        taskAssignmentDao.insert(taskAssignments)
+        taskAssignmentDao.clearAndInsert(taskAssignments)
     }
 
     suspend fun update(assignment: TaskAssignment, readyForUpload: Boolean): Int {


### PR DESCRIPTION
Put refresh operation in view model in long running scope so that it
doesn't get cancelled midway if vm is cleared
Restored clearAndInsert for assignments on refresh because it should be
safe afterall
