### PR TITLE
Fix bug with action request code

### DIFF
--- a/android/src/main/java/com/ramitsuri/choresclient/android/notification/AssignmentActionReceiver.kt
+++ b/android/src/main/java/com/ramitsuri/choresclient/android/notification/AssignmentActionReceiver.kt
@@ -42,7 +42,6 @@ class AssignmentActionReceiver : BroadcastReceiver() {
         val notificationId = intent.getIntExtra(NotificationActionExtra.KEY_NOTIFICATION_ID, -1)
         val notificationText = intent.getStringExtra(NotificationActionExtra.KEY_NOTIFICATION_TEXT)
             ?: requireNotNull(context).getString(R.string.notification_reminder_message)
-        Timber.i("Action: $action, Assignment: $assignmentId, Notification: $notificationId, $notificationText")
         when (action) {
             NotificationAction.SNOOZE_HOUR.action -> {
                 onSnoozeHourRequested(assignmentId, notificationId, notificationText)
@@ -67,6 +66,7 @@ class AssignmentActionReceiver : BroadcastReceiver() {
         notificationId: Int,
         notificationText: String
     ) {
+        Timber.i("Action snooze hour requested for $assignmentId, $notificationId")
         val snoozeBySeconds = Base.SNOOZE_HOUR
         snooze(assignmentId, notificationId, notificationText, snoozeBySeconds)
     }
@@ -76,6 +76,7 @@ class AssignmentActionReceiver : BroadcastReceiver() {
         notificationId: Int,
         notificationText: String
     ) {
+        Timber.i("Action snooze day requested for $assignmentId, $notificationId")
         val snoozeBySeconds = Base.SNOOZE_DAY
         snooze(assignmentId, notificationId, notificationText, snoozeBySeconds)
     }
@@ -98,6 +99,7 @@ class AssignmentActionReceiver : BroadcastReceiver() {
     }
 
     private fun onCompleteRequested(assignmentId: String) {
+        Timber.i("Action complete requested for $assignmentId")
         coroutineScope.launch(dispatcherProvider.io) {
             val assignment = repo.getLocal(assignmentId)
             if (assignment != null) {

--- a/android/src/main/java/com/ramitsuri/choresclient/android/notification/Models.kt
+++ b/android/src/main/java/com/ramitsuri/choresclient/android/notification/Models.kt
@@ -39,8 +39,7 @@ data class NotificationInfo(
 data class NotificationActionInfo(
     val action: String,
     @StringRes val textResId: Int,
-    val intentReceiverClass: Class<*>,
-    val requestCode: Int
+    val intentReceiverClass: Class<*>
 )
 
 enum class Importance(private val platformValue: Int) {

--- a/android/src/main/java/com/ramitsuri/choresclient/android/notification/ShowNotificationWorker.kt
+++ b/android/src/main/java/com/ramitsuri/choresclient/android/notification/ShowNotificationWorker.kt
@@ -54,20 +54,17 @@ class ShowNotificationWorker @AssistedInject constructor(
                     NotificationActionInfo(
                         NotificationAction.SNOOZE_HOUR.action,
                         NotificationAction.SNOOZE_HOUR.text,
-                        AssignmentActionReceiver::class.java,
-                        NotificationAction.SNOOZE_HOUR.requestCode
+                        AssignmentActionReceiver::class.java
                     ),
                     NotificationActionInfo(
                         NotificationAction.SNOOZE_DAY.action,
                         NotificationAction.SNOOZE_DAY.text,
-                        AssignmentActionReceiver::class.java,
-                        NotificationAction.SNOOZE_DAY.requestCode
+                        AssignmentActionReceiver::class.java
                     ),
                     NotificationActionInfo(
                         NotificationAction.COMPLETE.action,
                         NotificationAction.COMPLETE.text,
-                        AssignmentActionReceiver::class.java,
-                        NotificationAction.COMPLETE.requestCode
+                        AssignmentActionReceiver::class.java
                     )
                 ),
                 mapOf(

--- a/android/src/main/java/com/ramitsuri/choresclient/android/notification/SystemNotificationHandler.kt
+++ b/android/src/main/java/com/ramitsuri/choresclient/android/notification/SystemNotificationHandler.kt
@@ -31,8 +31,15 @@ class SystemNotificationHandler(context: Context) : NotificationHandler {
             setContentTitle(context.getString(notificationInfo.titleResId))
             setContentText(notificationInfo.body)
             if (notificationInfo.actions != null) {
-                for (action in notificationInfo.actions) {
-                    addAction(getAction(action, notificationInfo.actionExtras))
+                for ((index, action) in notificationInfo.actions.withIndex()) {
+                    addAction(
+                        getAction(
+                            notificationInfo.id,
+                            index,
+                            action,
+                            notificationInfo.actionExtras
+                        )
+                    )
                 }
             }
             setAutoCancel(true)
@@ -47,9 +54,12 @@ class SystemNotificationHandler(context: Context) : NotificationHandler {
     }
 
     private fun getAction(
+        notificationId: Int,
+        actionIndex: Int,
         actionInfo: NotificationActionInfo,
         actionExtras: Map<String, Any>?
     ): NotificationCompat.Action {
+        val actionRequestCode = notificationId * 10 + actionIndex
         val intent = Intent(context, actionInfo.intentReceiverClass)
         intent.action = actionInfo.action
         actionExtras?.forEach { (extraKey, extraValue) ->
@@ -70,7 +80,7 @@ class SystemNotificationHandler(context: Context) : NotificationHandler {
         }
         val pendingIntent = PendingIntent.getBroadcast(
             context,
-            actionInfo.requestCode,
+            actionRequestCode,
             intent,
             PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
         )

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -21,8 +21,8 @@
     <string name="notification_reminders_id">Reminders</string>
     <string name="notification_reminders_name">Reminders</string>
     <string name="notification_reminders_description">Notifications to remind you about due tasks</string>
-    <string name="notification_reminder_title">Task due</string>
-    <string name="notification_reminder_message">You have task(s) due. Open the app to check</string>
+    <string name="notification_reminder_title">Chore due</string>
+    <string name="notification_reminder_message">You have a chore due. Open the app to check</string>
     <string name="notification_reminder_action_snooze_six_hours">6 hours</string>
     <string name="notification_reminder_action_snooze_tomorrow">Tomorrow</string>
     <string name="notification_reminder_action_complete">Done</string>


### PR DESCRIPTION
If there are multiple notifications shown at the same time, all of their
actions are supposed to have a unique request code for their pending
intent otherwise the last one ends up overriding other ones and actions
don't work for any of the notifications except for the last one.

Changed the code to derive request code from notification id so that
it's always unique
