### PR TITLE
Add more logging

### DIFF
--- a/shared/src/commonMain/kotlin/com/ramitsuri/choresclient/repositories/AssignmentDetailsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/choresclient/repositories/AssignmentDetailsRepository.kt
@@ -78,7 +78,6 @@ class AssignmentDetailsRepository(
         logger.v(TAG, "Cancel requested for $assignmentId")
         val existing = alarmHandler.getExisting(assignmentId)
         existing?.let {
-            logger.v(TAG, "Existing $assignmentId found, cancelling notification")
             notificationHandler.cancelNotification(it.systemNotificationId.toInt())
         } ?: run {
             logger.v(TAG, "Existing $assignmentId not found, cannot cancel notification")


### PR DESCRIPTION
Discovered that there's some issue marking an assignment as done maybe.
So added more logging around that.

Log for when an assignment is marked done. The uploaded list is empty
which shouldn't be the case. But because that is the case, the completed
assignment is overwritten by the new copy that gets downloaded. So added
more logging around this to figure out what the issue is
```
"2022-06-03 09.35.44.020 AssignmentActionReceiver: Marked acd56508-3d19-47f6-a893-458a261798fd as done"
"2022-06-03 09.35.44.053 AssignmentDetailsRepository: Complete requested for acd56508-3d19-47f6-a893-458a261798fd"
"2022-06-03 09.35.44.066 SystemAlarmHandler: Cancel requested for [acd56508-3d19-47f6-a893-458a261798fd]"
"2022-06-03 09.35.44.081 SystemTaskAssignmentsRepository: Mark acd56508-3d19-47f6-a893-458a261798fd done completed"
"2022-06-03 09.35.49.728 SystemTaskAssignmentsRepository: Uploaded: "
"2022-06-03 09.35.51.057 SystemTaskAssignmentsRepository: Fetched: acd56508-3d19-47f6-a893-458a261798fd, 3ab8bacd-3f73-41c3-8071-615f9b28065b, 38f2a5b9-6536-457d-969c-3b8ae7ea27b6, 4b8ab503-1ea3-49f3-9af6-035a6ee72330, c34d714b-f966-47c9-840a-96d680bbc359, faec7ac9-95c4-4c08-acd7-58fee840bf46, c210dd81-5b09-4447-9009-06c9899f8f14, cf1f74fe-decc-404a-b433-758a9adec404, d2b9563e-7304-43a8-bcaa-16791657ecd9, e94c7f14-7f48-4ef2-b5d6-6ad380490e64, da0f26ff-3f1f-47a6-b7ab-dce4f03fb0cb"
"2022-06-03 09.35.51.067 AssignmentsDownloader: Run complete"
```
