### PR TITLE
Attempt to fix assignments getting overwritten

### DIFF
--- a/shared/src/commonMain/kotlin/com/ramitsuri/choresclient/data/entities/TaskAssignment.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/choresclient/data/entities/TaskAssignment.kt
@@ -85,23 +85,6 @@ class TaskAssignmentDao(
         }
     }
 
-    suspend fun clearAndInsert(taskAssignmentEntities: List<TaskAssignmentEntity>) {
-        withContext(dispatcherProvider.io) {
-            val todo = getTodo()
-            dbQueries.transaction {
-                // Delete only incomplete assignments and not completed ones that haven't been uploaded.
-                // Even though it's unlikely to happen that a completed assignment is not uploaded at this
-                // point in the real flow
-                todo.forEach {
-                    delete(it.id)
-                }
-                taskAssignmentEntities.forEach {
-                    insert(it)
-                }
-            }
-        }
-    }
-
     private fun delete(id: String) {
         dbQueries.deleteAssignment(id)
     }

--- a/shared/src/commonMain/kotlin/com/ramitsuri/choresclient/repositories/TaskAssignmentDataSource.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/choresclient/repositories/TaskAssignmentDataSource.kt
@@ -34,8 +34,8 @@ class TaskAssignmentDataSource(
 
         val taskAssignments = assignments.map { taskAssignmentToTaskAssignmentEntity(it) }
         // Do not do clearAndInsert as there might be local assignments that have been completed
-        // but not uploaded
-        taskAssignmentDao.clearAndInsert(taskAssignments)
+        // but not uploaded. The insert statement here ignores a row if it already exists.
+        taskAssignmentDao.insert(taskAssignments)
     }
 
     suspend fun markDone(assignmentId: String, doneTime: Instant) {

--- a/shared/src/commonMain/sqldelight/com/ramitsuri/choresclient/db/ChoresDatabase.sq
+++ b/shared/src/commonMain/sqldelight/com/ramitsuri/choresclient/db/ChoresDatabase.sq
@@ -55,7 +55,7 @@ SET progressStatus = ?, progressStatusDate = ?, shouldUpload = ?
 WHERE id = ?;
 
 insertAssignment:
-INSERT OR REPLACE INTO
+INSERT OR IGNORE INTO
 TaskAssignmentEntity (id, progressStatus, progressStatusDate, taskId, memberId, dueDateTime, createDate, createType, shouldUpload)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);
 


### PR DESCRIPTION
When an assignment is marked as done from notification, it sometimes
results in waking up the app and triggering the "upload existing,
download new assignments" worker. Since db access is not serialized,
worker sometimes picks up the old list of existing assignments. This
results in the assignment never getting uploaded and then also it
getting replaced by what's downloaded from the backend.

Changed the logic to not replace existing row with what we get from
backend since that would likely never be intended (at least right now).
If a row exists, then it is skipped and not saved again to db.
