### PR TITLE
Delete all todo assignments when fetching new

### DIFF
--- a/shared/src/commonMain/kotlin/com/ramitsuri/choresclient/data/entities/TaskAssignment.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/choresclient/data/entities/TaskAssignment.kt
@@ -18,33 +18,9 @@ class TaskAssignmentDao(
         }
     }
 
-    suspend fun getTodo(): List<TaskAssignmentEntity> {
-        return withContext(dispatcherProvider.io) {
-            return@withContext dbQueries.selectTodoAssignments().executeAsList()
-        }
-    }
-
     suspend fun get(id: String): TaskAssignmentEntity? {
         return withContext(dispatcherProvider.io) {
             return@withContext dbQueries.selectAssignment(id).executeAsOneOrNull()
-        }
-    }
-
-    suspend fun getForMember(memberId: String): List<TaskAssignmentEntity> {
-        return withContext(dispatcherProvider.io) {
-            return@withContext dbQueries.selectAssignmentsByMember(memberId).executeAsList()
-        }
-    }
-
-    suspend fun getForMembers(memberIds: List<String>): List<TaskAssignmentEntity> {
-        return withContext(dispatcherProvider.io) {
-            val result = mutableListOf<TaskAssignmentEntity>()
-            dbQueries.transaction {
-                memberIds.forEach { memberId ->
-                    result.addAll(dbQueries.selectAssignmentsByMembers(memberId).executeAsList())
-                }
-            }
-            return@withContext result
         }
     }
 
@@ -73,28 +49,15 @@ class TaskAssignmentDao(
         }
     }
 
-    suspend fun insert(taskAssignmentEntities: List<TaskAssignmentEntity>) {
+    suspend fun clearTodoAndInsert(taskAssignmentEntities: List<TaskAssignmentEntity>) {
         withContext(dispatcherProvider.io) {
             dbQueries.transaction {
+                dbQueries.deleteTodo()
                 taskAssignmentEntities.forEach {
                     insert(it)
                 }
             }
         }
-    }
-
-    suspend fun delete(ids: List<String>) {
-        withContext(dispatcherProvider.io) {
-            dbQueries.transaction {
-                ids.forEach {
-                    delete(it)
-                }
-            }
-        }
-    }
-
-    private fun delete(id: String) {
-        dbQueries.deleteAssignment(id)
     }
 
     private fun insert(taskAssignmentEntity: TaskAssignmentEntity) {

--- a/shared/src/commonMain/kotlin/com/ramitsuri/choresclient/repositories/TaskAssignmentDataSource.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/choresclient/repositories/TaskAssignmentDataSource.kt
@@ -35,9 +35,7 @@ class TaskAssignmentDataSource(
         taskDao.clearAndInsert(tasks)
 
         val taskAssignments = assignments.map { taskAssignmentToTaskAssignmentEntity(it) }
-        // Do not do clearAndInsert as there might be local assignments that have been completed
-        // but not uploaded. The insert statement here ignores a row if it already exists.
-        taskAssignmentDao.insert(taskAssignments)
+        taskAssignmentDao.clearTodoAndInsert(taskAssignments)
     }
 
     suspend fun markDone(assignmentId: String, doneTime: Instant) {
@@ -114,10 +112,6 @@ class TaskAssignmentDataSource(
 
     suspend fun getReadyForUpload(): List<TaskAssignment> {
         return toTaskAssignments(taskAssignmentDao.getForUpload())
-    }
-
-    suspend fun delete(taskAssignmentIds: List<String>) {
-        taskAssignmentDao.delete(taskAssignmentIds)
     }
 
     private suspend fun toTaskAssignments(

--- a/shared/src/commonMain/kotlin/com/ramitsuri/choresclient/repositories/TaskAssignmentsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/ramitsuri/choresclient/repositories/TaskAssignmentsRepository.kt
@@ -25,10 +25,7 @@ class SystemTaskAssignmentsRepository(
     private val logger: LogHelper by inject()
     override suspend fun refresh(): Result<List<TaskAssignment>> {
         // Upload completed local assignments
-        val uploadedIds = uploadLocal()
-
-        // Delete Ids that have been confirmed to be deleted by server
-        localDataSource.delete(uploadedIds)
+        uploadLocal()
 
         // Fetch from server and save locally. Return locally saved ones
         val fetchedAndSaved = fetchAndSave()

--- a/shared/src/commonMain/sqldelight/com/ramitsuri/choresclient/db/ChoresDatabase.sq
+++ b/shared/src/commonMain/sqldelight/com/ramitsuri/choresclient/db/ChoresDatabase.sq
@@ -27,25 +27,9 @@ SELECT * FROM TaskAssignmentEntity;
  * INNER JOIN TaskEntity ON TaskAssignmentEntity.taskId = TaskEntity.id;
  */
 
-selectTodoAssignments:
-SELECT * FROM TaskAssignmentEntity
-WHERE progressStatus = 1;
-
 selectAssignment:
 SELECT * FROM TaskAssignmentEntity
 WHERE id = :id;
-
-selectAssignmentsByMember:
-SELECT * FROM TaskAssignmentEntity
-WHERE memberId = ?;
-
-selectAssignmentsByMembers:
-SELECT * FROM TaskAssignmentEntity
-WHERE memberId IN (?);
-
-selectAssignmentsSince:
-SELECT * FROM TaskAssignmentEntity
-WHERE dueDateTime >= ?;
 
 selectAssignmentsForUpload:
 SELECT * FROM TaskAssignmentEntity
@@ -61,9 +45,9 @@ INSERT OR IGNORE INTO
 TaskAssignmentEntity (id, progressStatus, progressStatusDate, taskId, memberId, dueDateTime, createDate, createType, shouldUpload)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);
 
-deleteAssignment:
+deleteTodo:
 DELETE FROM TaskAssignmentEntity
-WHERE id IN (?);
+WHERE progressStatus = 1;
 
 /**
  * MEMBER


### PR DESCRIPTION
There was an issue in the previous logic where only the ones that get
uploaded were cleared off from database. This means that only the ones
for the user logged in, would ever get deleted from the database, as
the user cannot mark other users' assignments as completed and hence
they would never get marked as ready for upload.

This changes that and deletes all assignments that are in TODO state and
replaced by the ones sent by backend.

Also deleted some unused DAO code.